### PR TITLE
Support for Asynchronous DAO

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,26 @@ public class CitizenDAO extends AbstractHBDAO<String, Citizen> {
 ```
 (see [CitizenDAO.java](./src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/CitizenDAO.java))
 
+Additionally, you can also create asynchronous DAO objects by extending `ReactiveHBDAO` as illustrated in the snippet below. Reactive DAOs are based on Java's
+`CompletableFuture` abstraction and require an `AsyncConnection` object to be supplied rather than `Connection`.
+
+```java
+import com.flipkart.hbaseobjectmapper.ReactiveHBDAO;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Citizen;
+
+import org.apache.hadoop.hbase.client.AsyncConnection;
+
+public class CitizenDAO extends ReactiveHBDAO<String, Citizen> {
+// in above, String is the 'row type' of Citizen
+
+    public CitizenDAO(AsyncConnection connection) {
+        super(connection); // if you need to customize your codec, you may use super(connection, codec)
+        // alternatively, you can construct CitizenDAO by passing instance of 'org.apache.hadoop.conf.Configuration'
+    }
+}
+```
+(see [reactive/CitizenDAO.java](./src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CitizenDAO.java))
+
 Once defined, you can instantiate your *data access object* as below:
 
 ```java
@@ -157,7 +177,7 @@ CitizenDAO citizenDao = new CitizenDAO(connection);
 (Details: [Connection](https://hbase.apache.org/2.0/apidocs/org/apache/hadoop/hbase/client/Connection.html)).
 So, it is recommended that you create `Connection` instance once and use it for the entire life cycle of your program across all the DAO classes that you create (such as above).
 
-Now, you can access, manipulate and persist records of `citizens` table as shown in below examples:
+Now, you can access, manipulate and persist records of `citizens` table as shown in below examples. Note that the signatures of the reactive DAO may differ; all operations return `CompletableFuture`s.
 
 Create new record:
 
@@ -317,7 +337,7 @@ Table citizenTable = citizenDao.getHBaseTable()
 ## Using this library for DDL operations
 The provided `HBAdmin` class helps you programatically create/delete tables.
 
-You may instantiate the class using `Connection` object:
+You may instantiate the class using `Connection` or `AsyncConnection` object:
 
 ```java
 import org.apache.hadoop.hbase.client.Connection;
@@ -325,7 +345,7 @@ import com.flipkart.hbaseobjectmapper.HBAdmin;
 
 // some code
 
-HBAdmin hbAdmin = new HBAdmin(connection);
+HBAdmin hbAdmin = HBAdmin.create(connection);
 ```
 
 Once instantiated, you may do the following DDL operations:

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <version.hbase>2.2.3.ACROMANTULA-SNAPSHOT</version.hbase>
         <jackson-version>2.11.0</jackson-version>
+        <version.junit>5.6.2</version.junit>
+        <version.guava>25.0-jre</version.guava>
     </properties>
     <distributionManagement>
         <repository>
@@ -97,7 +99,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>${version.guava}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
@@ -132,7 +134,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.6.2</version>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -225,7 +233,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <forkCount>2</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,22 @@
             <organization>Flipkart</organization>
             <organizationUrl>https://www.flipkart.com</organizationUrl>
         </developer>
+        <developer>
+            <id>amrith92</id>
+            <name>Shroff Amrith Nayak</name>
+            <email>amrith92(plus)gh(at)gmail(dot)com</email>
+            <roles>
+                <role>design</role>
+                <role>development</role>
+            </roles>
+            <organization>Flipkart</organization>
+            <organizationUrl>https://www.flipkart.com</organizationUrl>
+        </developer>
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.hbase>2.2.1</version.hbase>
+        <version.hbase>2.2.3.ACROMANTULA-SNAPSHOT</version.hbase>
         <jackson-version>2.11.0</jackson-version>
     </properties>
     <distributionManagement>
@@ -48,6 +59,24 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    <repositories>
+        <repository>
+        <id>flipkart.artifactory</id>
+        <name>Flipkart Artifactory</name>
+        <url>http://artifactory.fkinternal.com/artifactory/v1.0/artifacts/libs-release-local</url>
+        <snapshots>
+            <enabled>false</enabled>
+        </snapshots>
+    </repository>
+    <repository>
+        <id>flipkart.artifactory.snapshots</id>
+        <name>Flipkart Artifactory (Snapshots)</name>
+        <url>http://artifactory.fkinternal.com/artifactory/v1.0/artifacts/libs-snapshots-local</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+    </repositories>
     <dependencies>
         <!-- Application dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.flipkart</groupId>
     <artifactId>hbase-object-mapper</artifactId>
-    <version>1.19-SNAPSHOT</version>
+    <version>1.19</version>
     <url>https://github.com/flipkart-incubator/hbase-orm</url>
     <scm>
         <url>https://github.com/flipkart-incubator/hbase-orm</url>
@@ -50,7 +50,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.hbase>2.2.3.ACROMANTULA-SNAPSHOT</version.hbase>
+        <version.hbase>2.2.3</version.hbase>
         <jackson-version>2.11.0</jackson-version>
         <version.junit>5.6.2</version.junit>
         <version.guava>25.0-jre</version.guava>
@@ -61,24 +61,6 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
-    <repositories>
-        <repository>
-        <id>flipkart.artifactory</id>
-        <name>Flipkart Artifactory</name>
-        <url>http://artifactory.fkinternal.com/artifactory/v1.0/artifacts/libs-release-local</url>
-        <snapshots>
-            <enabled>false</enabled>
-        </snapshots>
-    </repository>
-    <repository>
-        <id>flipkart.artifactory.snapshots</id>
-        <name>Flipkart Artifactory (Snapshots)</name>
-        <url>http://artifactory.fkinternal.com/artifactory/v1.0/artifacts/libs-snapshots-local</url>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </repository>
-    </repositories>
     <dependencies>
         <!-- Application dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.flipkart</groupId>
     <artifactId>hbase-object-mapper</artifactId>
-    <version>1.18</version>
+    <version>1.19-SNAPSHOT</version>
     <url>https://github.com/flipkart-incubator/hbase-orm</url>
     <scm>
         <url>https://github.com/flipkart-incubator/hbase-orm</url>
@@ -39,8 +39,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.hbase>2.0.6</version.hbase>
-        <jackson-version>2.10.4</jackson-version>
+        <version.hbase>2.2.1</version.hbase>
+        <jackson-version>2.11.0</jackson-version>
     </properties>
     <distributionManagement>
         <repository>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>29.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/src/main/java/com/flipkart/hbaseobjectmapper/AsyncHBAdmin.java
+++ b/src/main/java/com/flipkart/hbaseobjectmapper/AsyncHBAdmin.java
@@ -1,0 +1,69 @@
+package com.flipkart.hbaseobjectmapper;
+
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.client.AsyncConnection;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+
+class AsyncHBAdmin implements HBAdmin {
+
+    private final AsyncConnection connection;
+
+    AsyncHBAdmin(final AsyncConnection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public void createNamespace(String namespace) {
+        connection.getAdmin().createNamespace(
+                NamespaceDescriptor.create(namespace).build())
+                .join();
+    }
+
+    @Override
+    public <R extends Serializable & Comparable<R>, T extends HBRecord<R>> void createTable(Class<T> hbRecordClass) throws IOException {
+        WrappedHBTable<R, T> wrappedHBTable = new WrappedHBTable<>(hbRecordClass);
+        TableDescriptorBuilder tableDescriptorBuilder = TableDescriptorBuilder.newBuilder(wrappedHBTable.getName());
+        for (Map.Entry<String, Integer> e : wrappedHBTable.getFamiliesAndVersions().entrySet()) {
+            tableDescriptorBuilder.setColumnFamily(
+                    ColumnFamilyDescriptorBuilder.newBuilder(
+                            Bytes.toBytes(e.getKey())
+                    ).setMaxVersions(e.getValue()).build());
+        }
+        connection.getAdmin().createTable(tableDescriptorBuilder.build())
+                .join();
+    }
+
+    @Override
+    public <R extends Serializable & Comparable<R>, T extends HBRecord<R>> void deleteTable(Class<T> hbRecordClass) throws IOException {
+        WrappedHBTable<R, T> wrappedHBTable = new WrappedHBTable<>(hbRecordClass);
+        connection.getAdmin().deleteTable(wrappedHBTable.getName())
+                .join();
+    }
+
+    @Override
+    public <R extends Serializable & Comparable<R>, T extends HBRecord<R>> void enableTable(Class<T> hbRecordClass) throws IOException {
+        WrappedHBTable<R, T> wrappedHBTable = new WrappedHBTable<>(hbRecordClass);
+        connection.getAdmin().enableTable(wrappedHBTable.getName())
+                .join();
+    }
+
+    @Override
+    public <R extends Serializable & Comparable<R>, T extends HBRecord<R>> void disableTable(Class<T> hbRecordClass) throws IOException {
+        WrappedHBTable<R, T> wrappedHBTable = new WrappedHBTable<>(hbRecordClass);
+        connection.getAdmin().disableTable(wrappedHBTable.getName())
+                .join();
+    }
+
+    @Override
+    public <R extends Serializable & Comparable<R>, T extends HBRecord<R>> boolean tableExists(Class<T> hbRecordClass) throws IOException {
+        WrappedHBTable<R, T> wrappedHBTable = new WrappedHBTable<>(hbRecordClass);
+        return connection.getAdmin().tableExists(wrappedHBTable.getName())
+                .join();
+    }
+}

--- a/src/main/java/com/flipkart/hbaseobjectmapper/BaseHBDAO.java
+++ b/src/main/java/com/flipkart/hbaseobjectmapper/BaseHBDAO.java
@@ -101,7 +101,7 @@ abstract class BaseHBDAO<R extends Serializable & Comparable<R>, T extends HBRec
     }
 
     /**
-     * Gets (native) {@link Increment} object for given row key, to be later used in {@link #increment(Increment)} method.
+     * Gets (native) {@link Increment} object for given row key, to be later used in increment method.
      *
      * @param rowKey HBase row key
      * @return Increment object
@@ -111,7 +111,7 @@ abstract class BaseHBDAO<R extends Serializable & Comparable<R>, T extends HBRec
     }
 
     /**
-     * Gets HBase's (native) {@link Append} object for given row key, to be later used in {@link #append(Append)} method.
+     * Gets HBase's (native) {@link Append} object for given row key, to be later used in append method.
      *
      * @param rowKey HBase row key
      * @return HBase's {@link Append} object

--- a/src/main/java/com/flipkart/hbaseobjectmapper/BaseHBDAO.java
+++ b/src/main/java/com/flipkart/hbaseobjectmapper/BaseHBDAO.java
@@ -1,0 +1,166 @@
+package com.flipkart.hbaseobjectmapper;
+
+import com.google.common.reflect.TypeToken;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Result;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+/**
+ * Base capabilities for HBase DAO.
+ *
+ * @param <R> Data type of row key, which should be '{@link Comparable} with itself' and must be {@link Serializable} (e.g. {@link String}, {@link Integer}, {@link BigDecimal} etc. or your own POJO)
+ * @param <T> Entity type that maps to an HBase row (this type must have implemented {@link HBRecord} interface)
+ */
+abstract class BaseHBDAO<R extends Serializable & Comparable<R>, T extends HBRecord<R>> {
+    protected final HBObjectMapper hbObjectMapper;
+    protected final Class<R> rowKeyClass;
+    protected final Class<T> hbRecordClass;
+    protected final WrappedHBTable<R, T> hbTable;
+    private final Map<String, Field> fields;
+
+    @SuppressWarnings({"unchecked", "UnstableApiUsage"})
+    protected BaseHBDAO(final HBObjectMapper hbObjectMapper) {
+        this.hbObjectMapper = hbObjectMapper;
+        hbRecordClass = (Class<T>) new TypeToken<T>(getClass()) {
+        }.getRawType();
+        if (hbRecordClass == null) {
+            throw new IllegalStateException("Unable to resolve HBase record type");
+        }
+        this.hbObjectMapper.validateHBClass(hbRecordClass);
+        this.rowKeyClass = (Class<R>) new TypeToken<R>(getClass()) {
+        }.getRawType();
+        if (rowKeyClass == null) {
+            throw new IllegalStateException("Unable to resolve HBase rowkey type");
+        }
+        this.hbTable = new WrappedHBTable<>(hbRecordClass);
+        this.fields = hbObjectMapper.getHBColumnFields0(hbRecordClass);
+    }
+
+    /**
+     * Get HBase table name
+     *
+     * @return Name of table read as String
+     */
+    public String getTableName() {
+        return hbRecordClass.getAnnotation(HBTable.class).name();
+    }
+
+    /**
+     * Get the mapped column families and their versions (as specified in {@link HBTable} annotation)
+     *
+     * @return A {@link Map} containing names of column families as mapped in the entity class and number of versions
+     */
+    public Map<String, Integer> getColumnFamiliesAndVersions() {
+        return hbObjectMapper.getColumnFamiliesAndVersions(hbRecordClass);
+    }
+
+    /**
+     * Get list of fields (private variables of your bean-like class)
+     *
+     * @return A {@link Set} containing names of fields
+     */
+    public Set<String> getFields() {
+        return fields.keySet();
+    }
+
+    /**
+     * Convert typed row key into a byte array
+     *
+     * @param rowKey Row key, as used in your code
+     * @return Byte array corresponding to HBase row key
+     */
+    public byte[] toBytes(R rowKey) {
+        return hbObjectMapper.rowKeyToBytes(rowKey, hbTable.getCodecFlags());
+    }
+
+    /**
+     * Creates an HBase {@link Get} object, for enabling specialised read of HBase rows.
+     * <br><br>
+     *
+     * @param rowKey Row key
+     * @return HBase's Get object
+     */
+    public Get getGet(@Nonnull final R rowKey) {
+        return new Get(toBytes(rowKey));
+    }
+
+    /**
+     * Gets (native) {@link Increment} object for given row key, to be later used in {@link #increment(Increment)} method.
+     *
+     * @param rowKey HBase row key
+     * @return Increment object
+     */
+    public Increment getIncrement(@Nonnull final R rowKey) {
+        return new Increment(toBytes(rowKey));
+    }
+
+    /**
+     * Gets HBase's (native) {@link Append} object for given row key, to be later used in {@link #append(Append)} method.
+     *
+     * @param rowKey HBase row key
+     * @return HBase's {@link Append} object
+     */
+    public Append getAppend(R rowKey) {
+        return new Append(toBytes(rowKey));
+    }
+
+    protected void populateFieldValuesToMap(final Field field, final Result result, final Map<R, NavigableMap<Long, Object>> map) {
+        if (result.isEmpty()) {
+            return;
+        }
+        WrappedHBColumn hbColumn = new WrappedHBColumn(field);
+        List<Cell> cells = result.getColumnCells(hbColumn.familyBytes(), hbColumn.columnBytes());
+        for (Cell cell : cells) {
+            Type fieldType = hbObjectMapper.getFieldType(field, hbColumn.isMultiVersioned());
+            @SuppressWarnings("unchecked") final R rowKey = hbObjectMapper.bytesToRowKey(CellUtil.cloneRow(cell), hbTable.getCodecFlags(), (Class<T>) field.getDeclaringClass());
+            if (!map.containsKey(rowKey)) {
+                map.put(rowKey, new TreeMap<>());
+            }
+            map.get(rowKey).put(cell.getTimestamp(), hbObjectMapper.byteArrayToValue(CellUtil.cloneValue(cell), fieldType, hbColumn.codecFlags()));
+        }
+    }
+
+    protected WrappedHBColumn validateAndGetLongColumn(@Nonnull final String fieldName) {
+        Field field = getField(fieldName);
+        if (!Long.class.equals(field.getType())) {
+            throw new IllegalArgumentException(String.format("Invalid attempt to increment a non-Long field (%s.%s)", hbRecordClass.getName(), fieldName));
+        }
+        return new WrappedHBColumn(field);
+    }
+
+    protected Field getField(@Nonnull final String fieldName) {
+        Field field = fields.get(fieldName);
+        if (field == null) {
+            throw new IllegalArgumentException(String.format("Unrecognized field: '%s'. Choose one of %s%n", fieldName, fields.keySet()));
+        }
+        return field;
+    }
+
+    protected Map<R, Object> toSingleVersioned(@Nonnull final Map<R, NavigableMap<Long, Object>> multiVersionedMap, final int mapInitialCapacity) {
+        final Map<R, Object> map = new HashMap<>(mapInitialCapacity, 1.0f);
+        for (final Map.Entry<R, NavigableMap<Long, Object>> e : multiVersionedMap.entrySet()) {
+            map.put(e.getKey(), e.getValue().lastEntry().getValue());
+        }
+        return map;
+    }
+
+    protected Function<Result, T> mapResultToRecordType() {
+        return result -> hbObjectMapper.readValueFromResult(result, hbRecordClass);
+    }
+}

--- a/src/main/java/com/flipkart/hbaseobjectmapper/ReactiveRecords.java
+++ b/src/main/java/com/flipkart/hbaseobjectmapper/ReactiveRecords.java
@@ -1,0 +1,35 @@
+package com.flipkart.hbaseobjectmapper;
+
+import org.apache.hadoop.hbase.client.ResultScanner;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+
+/**
+ * Records derived from the asynchronous variant of HBase DAO.
+ *
+ * @param <T> a record type
+ */
+@SuppressWarnings("rawtypes")
+public class ReactiveRecords<T extends HBRecord> implements Records<T> {
+
+    private final HBObjectMapper hbObjectMapper;
+    private final Class<T> clazz;
+    private final ResultScanner scanner;
+
+    public ReactiveRecords(@Nonnull final ResultScanner scanner, @Nonnull final HBObjectMapper hbObjectMapper, @Nonnull final Class<T> clazz) {
+        this.hbObjectMapper = hbObjectMapper;
+        this.clazz = clazz;
+        this.scanner = scanner;
+    }
+
+    @Override
+    public void close() {
+        scanner.close();
+    }
+
+    @Override @Nonnull
+    public Iterator<T> iterator() {
+        return new RecordsIterator<>(hbObjectMapper, clazz, scanner.iterator());
+    }
+}

--- a/src/main/java/com/flipkart/hbaseobjectmapper/Records.java
+++ b/src/main/java/com/flipkart/hbaseobjectmapper/Records.java
@@ -1,13 +1,11 @@
 package com.flipkart.hbaseobjectmapper;
 
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.*;
-
-import java.io.*;
-import java.util.Iterator;
+import java.io.Closeable;
+import java.io.Serializable;
 
 /**
- * This class is the return type of all 'records' methods of {@link AbstractHBDAO} class, which enable you to iterate over large number of records (e.g. {@link AbstractHBDAO#records(Serializable, Serializable) AbstractHBDAO.records(R, R)})
+ * This class is the return type of all 'records' methods of {@link AbstractHBDAO} & {@link ReactiveHBDAO} classes, which enable you to iterate over large number of records
+ * (e.g. {@link AbstractHBDAO#records(Serializable, Serializable) AbstractHBDAO.records(R, R)}).
  * <br><br>
  * Users of this library are <u>not</u> expected to instantiate this class on their own.
  * <br><br>
@@ -16,29 +14,5 @@ import java.util.Iterator;
  * @param <T> record type
  */
 @SuppressWarnings("rawtypes")
-public class Records<T extends HBRecord> implements Closeable, Iterable<T> {
-    private final HBObjectMapper hbObjectMapper;
-    private final Class<T> clazz;
-    private final Table table;
-    private final ResultScanner scanner;
-
-    Records(Connection connection, HBObjectMapper hbObjectMapper, Class<T> clazz, TableName tableName, Scan scan) throws IOException {
-        this.hbObjectMapper = hbObjectMapper;
-        this.clazz = clazz;
-        this.table = connection.getTable(tableName);
-        this.scanner = table.getScanner(scan);
-    }
-
-    @Override
-    public void close() throws IOException {
-        scanner.close();
-        table.close();
-    }
-
-    @SuppressWarnings("NullableProblems")
-    @Override
-    public Iterator<T> iterator() {
-        return new RecordsIterator<>(hbObjectMapper, clazz, scanner.iterator());
-    }
-
+public interface Records<T extends HBRecord> extends Closeable, Iterable<T> {
 }

--- a/src/main/java/com/flipkart/hbaseobjectmapper/Records.java
+++ b/src/main/java/com/flipkart/hbaseobjectmapper/Records.java
@@ -4,7 +4,7 @@ import java.io.Closeable;
 import java.io.Serializable;
 
 /**
- * This class is the return type of all 'records' methods of {@link AbstractHBDAO} & {@link ReactiveHBDAO} classes, which enable you to iterate over large number of records
+ * This class is the return type of all 'records' methods of {@link AbstractHBDAO} &amp; {@link ReactiveHBDAO} classes, which enable you to iterate over large number of records
  * (e.g. {@link AbstractHBDAO#records(Serializable, Serializable) AbstractHBDAO.records(R, R)}).
  * <br><br>
  * Users of this library are <u>not</u> expected to instantiate this class on their own.

--- a/src/main/java/com/flipkart/hbaseobjectmapper/SyncHBAdmin.java
+++ b/src/main/java/com/flipkart/hbaseobjectmapper/SyncHBAdmin.java
@@ -1,0 +1,84 @@
+package com.flipkart.hbaseobjectmapper;
+
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * A minimal administrative API (wrapper over HBase's {@link Admin})
+ */
+class SyncHBAdmin implements HBAdmin {
+    private final Connection connection;
+
+    /**
+     * Constructs {@link SyncHBAdmin} object
+     *
+     * @param connection HBase connection
+     */
+    public SyncHBAdmin(Connection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public void createNamespace(String namespace) throws IOException {
+        final NamespaceDescriptor namespaceDescriptor = NamespaceDescriptor.create(namespace).build();
+        try (Admin admin = connection.getAdmin()) {
+            admin.createNamespace(namespaceDescriptor);
+        }
+    }
+
+    @Override
+    public <R extends Serializable & Comparable<R>, T extends HBRecord<R>> void createTable(Class<T> hbRecordClass) throws IOException {
+        try (Admin admin = connection.getAdmin()) {
+            WrappedHBTable<R, T> wrappedHBTable = new WrappedHBTable<>(hbRecordClass);
+            TableDescriptorBuilder tableDescriptorBuilder = TableDescriptorBuilder.newBuilder(wrappedHBTable.getName());
+            for (Map.Entry<String, Integer> e : wrappedHBTable.getFamiliesAndVersions().entrySet()) {
+                tableDescriptorBuilder.setColumnFamily(
+                        ColumnFamilyDescriptorBuilder.newBuilder(
+                                Bytes.toBytes(e.getKey())
+                        ).setMaxVersions(e.getValue()).build());
+            }
+            admin.createTable(tableDescriptorBuilder.build());
+        }
+    }
+
+    @Override
+    public <R extends Serializable & Comparable<R>, T extends HBRecord<R>> void deleteTable(Class<T> hbRecordClass) throws IOException {
+        try (Admin admin = connection.getAdmin()) {
+            WrappedHBTable<R, T> wrappedHBTable = new WrappedHBTable<>(hbRecordClass);
+            admin.deleteTable(wrappedHBTable.getName());
+        }
+    }
+
+    @Override
+    public <R extends Serializable & Comparable<R>, T extends HBRecord<R>> void enableTable(Class<T> hbRecordClass) throws IOException {
+        try (Admin admin = connection.getAdmin()) {
+            WrappedHBTable<R, T> wrappedHBTable = new WrappedHBTable<>(hbRecordClass);
+            admin.enableTable(wrappedHBTable.getName());
+        }
+    }
+
+    @Override
+    public <R extends Serializable & Comparable<R>, T extends HBRecord<R>> void disableTable(Class<T> hbRecordClass) throws IOException {
+        try (Admin admin = connection.getAdmin()) {
+            WrappedHBTable<R, T> wrappedHBTable = new WrappedHBTable<>(hbRecordClass);
+            admin.disableTable(wrappedHBTable.getName());
+        }
+    }
+
+    @Override
+    public <R extends Serializable & Comparable<R>, T extends HBRecord<R>> boolean tableExists(Class<T> hbRecordClass) throws IOException {
+        try (Admin admin = connection.getAdmin()) {
+            WrappedHBTable<R, T> wrappedHBTable = new WrappedHBTable<>(hbRecordClass);
+            return admin.tableExists(wrappedHBTable.getName());
+        }
+    }
+
+}

--- a/src/main/java/com/flipkart/hbaseobjectmapper/SyncRecords.java
+++ b/src/main/java/com/flipkart/hbaseobjectmapper/SyncRecords.java
@@ -1,0 +1,43 @@
+package com.flipkart.hbaseobjectmapper;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * Records derived from the synchronous variant of HBase DAO.
+ *
+ * @param <T> a record type
+ */
+@SuppressWarnings("rawtypes")
+public class SyncRecords<T extends HBRecord> implements Records<T> {
+    private final HBObjectMapper hbObjectMapper;
+    private final Class<T> clazz;
+    private final Table table;
+    private final ResultScanner scanner;
+
+    SyncRecords(Connection connection, HBObjectMapper hbObjectMapper, Class<T> clazz, TableName tableName, Scan scan) throws IOException {
+        this.hbObjectMapper = hbObjectMapper;
+        this.clazz = clazz;
+        this.table = connection.getTable(tableName);
+        this.scanner = table.getScanner(scan);
+    }
+
+    @Override
+    public void close() throws IOException {
+        scanner.close();
+        table.close();
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public Iterator<T> iterator() {
+        return new RecordsIterator<>(hbObjectMapper, clazz, scanner.iterator());
+    }
+
+}

--- a/src/main/java/com/flipkart/hbaseobjectmapper/exceptions/InvalidReadVersionsCountException.java
+++ b/src/main/java/com/flipkart/hbaseobjectmapper/exceptions/InvalidReadVersionsCountException.java
@@ -1,0 +1,7 @@
+package com.flipkart.hbaseobjectmapper.exceptions;
+
+public class InvalidReadVersionsCountException extends IllegalArgumentException {
+    public InvalidReadVersionsCountException(final String aCause) {
+        super(aCause);
+    }
+}

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/BaseHBDAOTests.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/BaseHBDAOTests.java
@@ -1,0 +1,70 @@
+package com.flipkart.hbaseobjectmapper.testcases;
+
+import com.flipkart.hbaseobjectmapper.HBAdmin;
+import com.flipkart.hbaseobjectmapper.HBRecord;
+import com.flipkart.hbaseobjectmapper.WrappedHBColumnTC;
+import com.flipkart.hbaseobjectmapper.WrappedHBTableTC;
+import com.flipkart.hbaseobjectmapper.codec.JavaObjectStreamCodec;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Citizen;
+import com.flipkart.hbaseobjectmapper.testcases.util.cluster.HBaseCluster;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+abstract class BaseHBDAOTests {
+
+    protected static HBAdmin hbAdmin;
+    protected static HBaseCluster hBaseCluster;
+
+    protected static <R extends Serializable & Comparable<R>, T extends HBRecord<R>> void deleteTables(Class... classes) throws IOException {
+        for (Class<T> clazz : classes) {
+            WrappedHBTableTC<R, T> hbTable = new WrappedHBTableTC<>(clazz);
+            if (hbAdmin.tableExists(clazz)) {
+                System.out.format("Deleting table '%s': ", hbTable);
+                hbAdmin.disableTable(clazz);
+                hbAdmin.deleteTable(clazz);
+                System.out.println("[DONE]");
+            }
+        }
+    }
+
+    protected static <R extends Serializable & Comparable<R>, T extends HBRecord<R>> void createTables(Class... classes) throws IOException {
+        for (Class<T> clazz : classes) {
+            WrappedHBTableTC<R, T> hbTable = new WrappedHBTableTC<>(clazz);
+            System.out.format("Creating table '%s': ", hbTable);
+            hbAdmin.createTable(clazz);
+            System.out.println("[DONE]");
+        }
+    }
+
+    protected <R extends Serializable & Comparable<R>, T extends HBRecord<R>> T pruneVersionsBeyond(T record, int versions) {
+        try {
+            T prunedRecord = JavaObjectStreamCodec.deepCopy(record);
+            for (Field field : Citizen.class.getDeclaredFields()) {
+                WrappedHBColumnTC hbColumn = new WrappedHBColumnTC(field);
+                if (hbColumn.isMultiVersioned()) {
+                    field.setAccessible(true);
+                    NavigableMap nm = (NavigableMap) field.get(prunedRecord);
+                    if (nm == null || nm.isEmpty())
+                        continue;
+                    NavigableMap temp = new TreeMap<>();
+                    for (int i = 0; i < versions; i++) {
+                        final Map.Entry entry = nm.pollLastEntry();
+                        if (entry == null)
+                            break;
+                        temp.put(entry.getKey(), entry.getValue());
+                    }
+                    field.set(prunedRecord, temp.isEmpty() ? null : temp);
+                }
+            }
+            return prunedRecord;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/TestsReactiveHBDAO.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/TestsReactiveHBDAO.java
@@ -3,8 +3,20 @@ package com.flipkart.hbaseobjectmapper.testcases;
 import com.flipkart.hbaseobjectmapper.HBAdmin;
 import com.flipkart.hbaseobjectmapper.Records;
 import com.flipkart.hbaseobjectmapper.WrappedHBColumnTC;
-import com.flipkart.hbaseobjectmapper.testcases.daos.reactive.*;
-import com.flipkart.hbaseobjectmapper.testcases.entities.*;
+import com.flipkart.hbaseobjectmapper.testcases.daos.reactive.CitizenDAO;
+import com.flipkart.hbaseobjectmapper.testcases.daos.reactive.CitizenSummaryDAO;
+import com.flipkart.hbaseobjectmapper.testcases.daos.reactive.CounterDAO;
+import com.flipkart.hbaseobjectmapper.testcases.daos.reactive.CrawlDAO;
+import com.flipkart.hbaseobjectmapper.testcases.daos.reactive.CrawlNoVersionDAO;
+import com.flipkart.hbaseobjectmapper.testcases.daos.reactive.EmployeeDAO;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Citizen;
+import com.flipkart.hbaseobjectmapper.testcases.entities.CitizenSummary;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Contact;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Counter;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Crawl;
+import com.flipkart.hbaseobjectmapper.testcases.entities.CrawlNoVersion;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Dependents;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Employee;
 import com.flipkart.hbaseobjectmapper.testcases.util.cluster.InMemoryHBaseCluster;
 import com.flipkart.hbaseobjectmapper.testcases.util.cluster.RealHBaseCluster;
 
@@ -20,12 +32,30 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import static com.flipkart.hbaseobjectmapper.testcases.util.LiteralsUtil.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.flipkart.hbaseobjectmapper.testcases.util.LiteralsUtil.a;
+import static com.flipkart.hbaseobjectmapper.testcases.util.LiteralsUtil.e;
+import static com.flipkart.hbaseobjectmapper.testcases.util.LiteralsUtil.l;
+import static com.flipkart.hbaseobjectmapper.testcases.util.LiteralsUtil.m;
+import static com.flipkart.hbaseobjectmapper.testcases.util.LiteralsUtil.nm;
+import static com.flipkart.hbaseobjectmapper.testcases.util.LiteralsUtil.s;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 // TODO: fix the tests. Currently, the tests are copied from the sync DAO as-is, but is not idiomatic with real reactive client usage.
 class TestsReactiveHBDAO extends BaseHBDAOTests {

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CitizenDAO.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CitizenDAO.java
@@ -1,0 +1,13 @@
+package com.flipkart.hbaseobjectmapper.testcases.daos.reactive;
+
+import com.flipkart.hbaseobjectmapper.ReactiveHBDAO;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Citizen;
+
+import org.apache.hadoop.hbase.client.AsyncConnection;
+
+public class CitizenDAO extends ReactiveHBDAO<String, Citizen> {
+
+    public CitizenDAO(AsyncConnection connection) {
+        super(connection);
+    }
+}

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CitizenSummaryDAO.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CitizenSummaryDAO.java
@@ -1,0 +1,16 @@
+package com.flipkart.hbaseobjectmapper.testcases.daos.reactive;
+
+
+import com.flipkart.hbaseobjectmapper.ReactiveHBDAO;
+import com.flipkart.hbaseobjectmapper.testcases.entities.CitizenSummary;
+
+import org.apache.hadoop.hbase.client.AsyncConnection;
+
+import java.io.IOException;
+
+public class CitizenSummaryDAO extends ReactiveHBDAO<String, CitizenSummary> {
+
+    public CitizenSummaryDAO(AsyncConnection connection) {
+        super(connection);
+    }
+}

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CounterDAO.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CounterDAO.java
@@ -1,0 +1,12 @@
+package com.flipkart.hbaseobjectmapper.testcases.daos.reactive;
+
+import com.flipkart.hbaseobjectmapper.ReactiveHBDAO;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Counter;
+
+import org.apache.hadoop.hbase.client.AsyncConnection;
+
+public class CounterDAO extends ReactiveHBDAO<String, Counter> {
+    public CounterDAO(AsyncConnection connection) {
+        super(connection);
+    }
+}

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CrawlDAO.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CrawlDAO.java
@@ -1,0 +1,14 @@
+package com.flipkart.hbaseobjectmapper.testcases.daos.reactive;
+
+
+import com.flipkart.hbaseobjectmapper.ReactiveHBDAO;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Crawl;
+
+import org.apache.hadoop.hbase.client.AsyncConnection;
+
+public class CrawlDAO extends ReactiveHBDAO<String, Crawl> {
+
+    public CrawlDAO(AsyncConnection connection) {
+        super(connection);
+    }
+}

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CrawlNoVersionDAO.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/CrawlNoVersionDAO.java
@@ -1,0 +1,14 @@
+package com.flipkart.hbaseobjectmapper.testcases.daos.reactive;
+
+
+import com.flipkart.hbaseobjectmapper.ReactiveHBDAO;
+import com.flipkart.hbaseobjectmapper.testcases.entities.CrawlNoVersion;
+
+import org.apache.hadoop.hbase.client.AsyncConnection;
+
+public class CrawlNoVersionDAO extends ReactiveHBDAO<String, CrawlNoVersion> {
+
+    public CrawlNoVersionDAO(AsyncConnection connection) {
+        super(connection);
+    }
+}

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/EmployeeDAO.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/daos/reactive/EmployeeDAO.java
@@ -1,0 +1,14 @@
+package com.flipkart.hbaseobjectmapper.testcases.daos.reactive;
+
+
+import com.flipkart.hbaseobjectmapper.ReactiveHBDAO;
+import com.flipkart.hbaseobjectmapper.testcases.entities.Employee;
+
+import org.apache.hadoop.hbase.client.AsyncConnection;
+
+public class EmployeeDAO extends ReactiveHBDAO<Long, Employee> {
+
+    public EmployeeDAO(AsyncConnection connection) {
+        super(connection);
+    }
+}

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/util/cluster/HBaseCluster.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/util/cluster/HBaseCluster.java
@@ -1,12 +1,16 @@
 package com.flipkart.hbaseobjectmapper.testcases.util.cluster;
 
+import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.Connection;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 public interface HBaseCluster {
 
     Connection start() throws IOException;
+
+    CompletableFuture<AsyncConnection> startAsync();
 
     void end() throws Exception;
 }

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/util/cluster/InMemoryHBaseCluster.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/util/cluster/InMemoryHBaseCluster.java
@@ -1,10 +1,15 @@
 package com.flipkart.hbaseobjectmapper.testcases.util.cluster;
 
 import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.StartMiniClusterOption;
+import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.flipkart.hbaseobjectmapper.testcases.util.cluster.RealHBaseCluster.USE_REAL_HBASE;
 
@@ -14,7 +19,7 @@ public class InMemoryHBaseCluster implements HBaseCluster {
     public static final String INMEMORY_CLUSTER_START_TIMEOUT = "INMEMORY_CLUSTER_START_TIMEOUT";
     private final HBaseTestingUtility utility;
     private final ExecutorService executorService;
-    private Connection connection;
+    private final AtomicReference<Object> connectionRef;
     private final long timeout;
 
     public InMemoryHBaseCluster() {
@@ -22,15 +27,59 @@ public class InMemoryHBaseCluster implements HBaseCluster {
     }
 
     public InMemoryHBaseCluster(long timeout) {
+        System.clearProperty("hadoop.tmp.dir");
+        System.setProperty("hbase.testing.preserve.testdir", "false");
         this.utility = new HBaseTestingUtility();
         this.executorService = Executors.newSingleThreadExecutor();
         this.timeout = timeout;
+        this.connectionRef = new AtomicReference<>();
     }
 
     public Connection start() throws IOException {
+        doStart();
+        final Connection connection = utility.getConnection();
+        if (connection == null) {
+            throw new IllegalStateException("Connection could not be established with in-memory HBase cluster");
+        }
+        this.connectionRef.set(connection);
+        return connection;
+    }
+
+    @Override
+    public CompletableFuture<AsyncConnection> startAsync() {
+
+        try {
+            doStart();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return ConnectionFactory.createAsyncConnection(utility.getConfiguration())
+                .thenApply(conn -> {
+                    connectionRef.set(conn);
+                    return conn;
+                });
+    }
+
+    @Override
+    public void end() throws Exception {
+        if (connectionRef.get() != null) {
+            if (connectionRef.get() instanceof Connection) {
+                ((Connection) connectionRef.get()).close();
+            } else {
+                ((AsyncConnection) connectionRef.get()).close();
+            }
+        }
+        utility.shutdownMiniCluster();
+    }
+
+    private void doStart() throws IOException {
         try {
             System.out.println("Starting in-memory HBase test cluster");
-            executorService.submit(() -> utility.startMiniCluster(1, 1, false)).get(timeout, TimeUnit.SECONDS);
+            executorService.submit(() -> utility.startMiniCluster(StartMiniClusterOption.builder()
+                    .numMasters(1)
+                    .numRegionServers(1)
+                    .createRootDir(false)
+                    .build())).get(timeout, TimeUnit.SECONDS);
         } catch (TimeoutException e) {
             throw new IllegalStateException(String.format(
                     "Starting an 'in-memory HBase cluster' took much longer than expected time of %d seconds. Aborting.%n" +
@@ -42,16 +91,5 @@ public class InMemoryHBaseCluster implements HBaseCluster {
         } catch (Exception e) {
             throw new IOException("Error starting an in-memory HBase cluster", e);
         }
-        connection = utility.getConnection();
-        if (connection == null) {
-            throw new IllegalStateException("Connection could not be established with in-memory HBase cluster");
-        }
-        return connection;
-    }
-
-    @Override
-    public void end() throws Exception {
-        connection.close();
-        utility.shutdownMiniCluster();
     }
 }

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/util/cluster/InMemoryHBaseCluster.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/util/cluster/InMemoryHBaseCluster.java
@@ -8,7 +8,11 @@ import org.apache.hadoop.hbase.client.ConnectionFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.flipkart.hbaseobjectmapper.testcases.util.cluster.RealHBaseCluster.USE_REAL_HBASE;

--- a/src/test/java/com/flipkart/hbaseobjectmapper/testcases/util/cluster/RealHBaseCluster.java
+++ b/src/test/java/com/flipkart/hbaseobjectmapper/testcases/util/cluster/RealHBaseCluster.java
@@ -2,25 +2,49 @@ package com.flipkart.hbaseobjectmapper.testcases.util.cluster;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class RealHBaseCluster implements HBaseCluster {
     public static final String USE_REAL_HBASE = "USE_REAL_HBASE";
-    private Connection connection;
+    private final AtomicReference<Object> connectionRef = new AtomicReference<>();
 
     @Override
     public Connection start() throws IOException {
-        System.out.println("Connecting to HBase cluster");
-        Configuration configuration = HBaseConfiguration.create();
-        connection = ConnectionFactory.createConnection(configuration);
+        final Configuration configuration = getConfiguration();
+        final Connection connection = ConnectionFactory.createConnection(configuration);
+        connectionRef.set(connection);
         return connection;
     }
 
     @Override
+    public CompletableFuture<AsyncConnection> startAsync() {
+        final Configuration configuration = getConfiguration();
+        return ConnectionFactory.createAsyncConnection(configuration)
+                .thenApply(conn -> {
+                    connectionRef.set(conn);
+                    return conn;
+                });
+    }
+
+    @Override
     public void end() throws IOException {
-        connection.close();
+        if (connectionRef.get() != null) {
+            if (connectionRef.get() instanceof Connection) {
+                ((Connection) connectionRef.get()).close();
+            } else {
+                ((AsyncConnection) connectionRef.get()).close();
+            }
+        }
+    }
+
+    private Configuration getConfiguration() {
+        System.out.println("Connecting to HBase cluster");
+        return HBaseConfiguration.create();
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces the option to use an asynchronous DAO implementation. It is aimed at applications that are already using a reactive programming paradigm.

With this PR, the HBase client version is upgraded from 2.0.x to 2.2.x as there are implementation weaknesses in batch table operations with the 2.0 & 2.1 series.

NB: The tests for the asynchronous DAO can be improved.